### PR TITLE
Bug 1205300 - Fix reporting documentation links

### DIFF
--- a/chart.cgi
+++ b/chart.cgi
@@ -69,7 +69,7 @@ if (grep(/^cmd-/, $cgi->param())) {
 
 my $action    = $cgi->param('action');
 my $series_id = $cgi->param('series_id');
-$vars->{'doc_section'} = 'reporting.html#charts';
+$vars->{'doc_section'} = 'using/reports-and-charts.html#charts';
 
 # Because some actions are chosen by buttons, we can't encode them as the value
 # of the action param, because that value is localization-dependent. So, we

--- a/report.cgi
+++ b/report.cgi
@@ -291,7 +291,7 @@ if ($vars->{debug}) {
 }
 
 # All formats point to the same section of the documentation.
-$vars->{'doc_section'} = 'reporting.html#reports';
+$vars->{'doc_section'} = 'using/reports-and-charts.html#reports';
 
 disable_utf8() if ($format->{'ctype'} =~ /^image\//);
 

--- a/template/en/default/global/user-error.html.tmpl
+++ b/template/en/default/global/user-error.html.tmpl
@@ -1015,12 +1015,12 @@
 
   [% ELSIF error == "illegal_series_creation" %]
     [% admindocslinks = {'groups.html' => 'Group security'} %]
-    [% docslinks = {'reporting.html' => 'Reporting'} %]
+    [% docslinks = {'using/reports-and-charts.html' => 'Reporting'} %]
     You are not authorized to create series.
 
   [% ELSIF error == "illegal_series_edit" %]
     [% admindocslinks = {'groups.html' => 'Group security'} %]
-    [% docslinks = {'reporting.html' => 'Reporting'} %]
+    [% docslinks = {'using/reports-and-charts.html' => 'Reporting'} %]
     You are not authorized to edit this series. To do this, you must either
     be its creator, or an administrator.
 
@@ -1037,7 +1037,7 @@
     The error was: [% dberror FILTER html %].
 
   [% ELSIF error == "insufficient_data_points" %]
-    [% docslinks = {'reporting.html' => 'Reporting'} %]
+    [% docslinks = {'using/reports-and-charts.html' => 'Reporting'} %]
     We don't have enough data points to make a graph (yet).
 
   [% ELSIF error == "invalid_attach_id" %]
@@ -1366,17 +1366,17 @@
 
   [% ELSIF error == "missing_datasets" %]
     [% title = "No Datasets Selected" %]
-    [% docslinks = {'reporting.html' => 'Reporting'} %]
+    [% docslinks = {'using/reports-and-charts.html' => 'Reporting'} %]
     You must specify one or more datasets to plot.
 
   [% ELSIF error == "missing_frequency" %]
     [% title = "Missing Frequency" %]
-    [% docslinks = {'reporting.html' => 'Reporting'} %]
+    [% docslinks = {'using/reports-and-charts.html' => 'Reporting'} %]
     You did not specify a valid frequency for this series.
 
   [% ELSIF error == "missing_name" %]
     [% title = "Missing Name" %]
-    [% docslinks = {'reporting.html' => 'Reporting'} %]
+    [% docslinks = {'using/reports-and-charts.html' => 'Reporting'} %]
     You did not specify a name for this series.
 
   [% ELSIF error == "missing_query" %]
@@ -1439,7 +1439,7 @@
 
   [% ELSIF error == "no_axes_defined" %]
     [% title = "No Axes Defined" %]
-    [% docslinks = {'reporting.html' => 'Reporting'} %]
+    [% docslinks = {'using/reports-and-charts.html' => 'Reporting'} %]
     You didn't define any axes to plot.
 
   [% ELSIF error == "no_bugs_chosen" %]
@@ -1781,7 +1781,7 @@
 
   [% ELSIF error == "series_already_exists" %]
     [% title = "Series Already Exists" %]
-    [% docslinks = {'reporting.html' => 'Reporting'} %]
+    [% docslinks = {'using/reports-and-charts.html' => 'Reporting'} %]
       A series named <em>[% series.category FILTER html %] /
       [%+ series.subcategory FILTER html %] /
       [%+ series.name FILTER html %]</em>

--- a/template/en/default/reports/menu.html.tmpl
+++ b/template/en/default/reports/menu.html.tmpl
@@ -27,7 +27,7 @@
 
 [% PROCESS global/header.html.tmpl
   title = "Reporting and Charting Kitchen"
-  doc_section = "reporting.html"
+  doc_section = "using/reports-and-charts.html"
 %]
 
 <p>

--- a/template/en/default/reports/old-charts.html.tmpl
+++ b/template/en/default/reports/old-charts.html.tmpl
@@ -24,7 +24,7 @@
 [% PROCESS global/header.html.tmpl
   title = "$terms.Bug Charts"
   h1 = "Welcome to the $terms.Bugzilla Charting Kitchen"
-  doc_section = "reporting.html#charts"
+  doc_section = "using/reports-and-charts.html#charts"
 %]
 
 <div align="center">

--- a/template/en/default/search/search-create-series.html.tmpl
+++ b/template/en/default/search/search-create-series.html.tmpl
@@ -37,7 +37,7 @@
   javascript = js_data
   javascript_urls = [ "js/productform.js", "js/TUI.js", "js/field.js", "js/advanced-search.js" ]
   style_urls = [ "skins/standard/search_form.css", "skins/standard/advanced-search.css" ]
-  doc_section = "reporting.html#charts-new-series"
+  doc_section = "using/reports-and-charts.html#charts-new-series"
 %]
 
 <form method="get" action="[% basepath FILTER none %]chart.cgi" name="chartform">

--- a/template/en/default/search/search-report-graph.html.tmpl
+++ b/template/en/default/search/search-report-graph.html.tmpl
@@ -36,7 +36,7 @@ var queryform = "reportform"
   javascript = js_data
   javascript_urls = [ "js/productform.js", "js/TUI.js", "js/field.js", "js/advanced-search.js" ]
   style_urls = [ "skins/standard/search_form.css", "skins/standard/advanced-search.css" ]
-  doc_section = "reporting.html#reports"
+  doc_section = "using/reports-and-charts.html#reports"
 %]
 
 [% PROCESS "search/search-report-select.html.tmpl" %]

--- a/template/en/default/search/search-report-table.html.tmpl
+++ b/template/en/default/search/search-report-table.html.tmpl
@@ -36,7 +36,7 @@ var queryform = "reportform"
   javascript = js_data
   javascript_urls = [ "js/productform.js", "js/TUI.js", "js/field.js", "js/advanced-search.js" ]
   style_urls = [ "skins/standard/search_form.css", "skins/standard/advanced-search.css" ]
-  doc_section = "reporting.html#reports"
+  doc_section = "using/reports-and-charts.html#reports"
 %]
 
 [% PROCESS "search/search-report-select.html.tmpl" %]


### PR DESCRIPTION
Bug 1205300 reports that Related documentation links on reporting pages and errors point to the removed `reporting.html` page.

This updates every reporting and charting documentation reference to `using/reports-and-charts.html`, preserving the relevant report, chart, and data-set anchors. Covering the report forms, generated output, chart pages, and related error messages prevents adjacent paths from retaining the same broken link.

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1205300

Test: `docker compose -f docker-compose.test.yml run --rm --no-deps bmo.test test_sanity t/004template.t`